### PR TITLE
Pin pydantic v1.10.19, prepare for pydantic v2 migration

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,4 +1,4 @@
-from pydantic import BaseSettings
+from pydantic.v1 import BaseSettings
 
 
 class Settings(BaseSettings):

--- a/app/models/hole_result.py
+++ b/app/models/hole_result.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from sqlmodel import Field, Relationship, SQLModel
 
 from app.models.hole import Hole, HoleRead

--- a/app/models/match.py
+++ b/app/models/match.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import List, Optional
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from sqlmodel import Field, Relationship, SQLModel
 
 from app.models.flight import Flight, FlightRead

--- a/app/models/round.py
+++ b/app/models/round.py
@@ -2,7 +2,7 @@ from datetime import date, datetime
 from enum import Enum
 from typing import List, Optional, Union
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from sqlmodel import Field, Relationship, SQLModel
 
 from app.models.golfer import Golfer, GolferRead

--- a/app/routers/tasks.py
+++ b/app/routers/tasks.py
@@ -6,7 +6,7 @@ import datetime
 from typing import List, Optional
 
 import fastapi
-import pydantic
+from pydantic.v1 import BaseModel
 
 from app.scheduler import app as app_scheduler
 
@@ -15,7 +15,7 @@ session = app_scheduler.session
 router = fastapi.APIRouter(prefix="/tasks", tags=["Tasks"])
 
 
-class Task(pydantic.BaseModel):
+class Task(BaseModel):
     name: str
     description: Optional[str]
     priority: int

--- a/app/utilities/notifications.py
+++ b/app/utilities/notifications.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List
 
 from fastapi import BackgroundTasks
 from fastapi_mail import ConnectionConfig, FastMail, MessageSchema, MessageType
-from pydantic import BaseModel, EmailStr
+from pydantic.v1 import BaseModel, EmailStr
 
 from app.dependencies import get_settings
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ numpy>=1.22.0,<3.0.0
 passlib[bcrypt]>=1.7.4,<2.0.0
 protobuf>=3.19.5,<6.0.0
 psycopg2>=2.9.5,<3.0.0
-pydantic[dotenv]>=1.8.2,<2.0.0
+pydantic[dotenv]==1.10.19
 pymongo>=4.3.3,<5.0.0
 python-jose[cryptography]>=3.3.0,<4.0.0
 python-multipart>=0.0.7,<1.0.0


### PR DESCRIPTION
Uses `pydantic.v1` namespace to simplify migration to `v2` at a later date.