### PR TITLE
Add flight divisions and statistics accessors

### DIFF
--- a/app/database/flights.py
+++ b/app/database/flights.py
@@ -8,13 +8,20 @@ from app.models.flight import (
     FlightInfo,
     FlightStandings,
     FlightStandingsTeam,
+    FlightStatistics,
+    FlightStatisticsGolfer,
     FlightTeam,
     FlightTeamGolfer,
 )
 from app.models.flight_division_link import FlightDivisionLink
 from app.models.flight_team_link import FlightTeamLink
 from app.models.golfer import Golfer
+from app.models.hole import Hole
+from app.models.hole_result import HoleResult
 from app.models.match import Match, MatchSummary
+from app.models.match_round_link import MatchRoundLink
+from app.models.round import Round
+from app.models.round_golfer_link import RoundGolferLink
 from app.models.team import Team
 from app.models.team_golfer_link import TeamGolferLink
 from app.models.tee import Tee
@@ -214,3 +221,122 @@ def get_standings(session: Session, flight_id: int) -> FlightStandings:
         flight_id=flight_id,
         teams=team_data,
     )
+
+
+def get_statistics(session: Session, flight_id: int) -> FlightStatistics:
+    matches = get_match_summaries(session=session, flight_id=flight_id)
+
+    flight_golfer_stats: dict[int, FlightStatisticsGolfer] = {}
+    golfer_rounds: dict[int, list[tuple[Match, Round]]] = {}
+    for match in matches:  # TODO: use 'in' in 'where' clause
+        match_data = session.exec(
+            select(Match, Round, Golfer, TeamGolferLink)
+            .join(MatchRoundLink, onclause=MatchRoundLink.match_id == Match.id)
+            .join(Round, onclause=Round.id == MatchRoundLink.round_id)
+            .join(RoundGolferLink, onclause=RoundGolferLink.round_id == Round.id)
+            .join(Golfer, onclause=Golfer.id == RoundGolferLink.golfer_id)
+            .join(TeamGolferLink, onclause=TeamGolferLink.golfer_id == Golfer.id)
+            .where(Match.id == match.match_id)
+            .where(TeamGolferLink.team_id.in_((match.home_team_id, match.away_team_id)))
+        ).all()
+
+        for match, match_round, match_golfer, match_tgl in match_data:
+            if match_golfer.id not in flight_golfer_stats:
+                flight_golfer_stats[match_golfer.id] = FlightStatisticsGolfer(
+                    golfer_id=match_golfer.id,
+                    golfer_name=match_golfer.name,
+                    golfer_team_id=match_tgl.team_id,
+                    golfer_team_role=match_tgl.role,
+                )
+
+            if match_golfer.id not in golfer_rounds:
+                golfer_rounds[match_golfer.id] = []
+            golfer_rounds[match_golfer.id].append((match, match_round))
+
+    for golfer_id, golfer_match_data in golfer_rounds.items():
+        golfer_stats = flight_golfer_stats[golfer_id]
+
+        for golfer_match, golfer_round in golfer_match_data:
+            golfer_stats.num_matches += 1
+            golfer_stats.num_rounds += 1  # TODO: track repeat rounds
+
+            # TODO: update total and average points won
+
+            par = 0
+            gross_score = 0
+            net_score = 0
+
+            round_data = session.exec(
+                select(HoleResult, Hole)
+                .join(Hole, onclause=Hole.id == HoleResult.hole_id)
+                .where(HoleResult.round_id == golfer_round.id)
+            ).all()
+            for hole_result, hole in round_data:
+                golfer_stats.num_holes += 1
+
+                par += hole.par
+                gross_score += hole_result.gross_score
+                net_score += hole_result.net_score
+
+                if hole_result.gross_score == 1:
+                    golfer_stats.num_aces += 1
+                elif hole_result.gross_score == (hole.par - 3):
+                    golfer_stats.num_albatrosses += 1
+                elif hole_result.gross_score == (hole.par - 2):
+                    golfer_stats.num_eagles += 1
+                elif hole_result.gross_score == (hole.par - 1):
+                    golfer_stats.num_birdies += 1
+                elif hole_result.gross_score == hole.par:
+                    golfer_stats.num_pars += 1
+                elif hole_result.gross_score == (hole.par + 1):
+                    golfer_stats.num_bogeys += 1
+                elif hole_result.gross_score == (hole.par + 2):
+                    golfer_stats.num_double_bogeys += 1
+                elif hole_result.gross_score > (hole.par + 2):
+                    golfer_stats.num_others += 1
+
+                if hole.par == 3:
+                    golfer_stats.num_par_3_holes += 1
+                    golfer_stats.avg_par_3_gross += (
+                        hole_result.gross_score - golfer_stats.avg_par_3_gross
+                    ) / golfer_stats.num_par_3_holes
+                    golfer_stats.avg_par_3_net += (
+                        hole_result.net_score - golfer_stats.avg_par_3_net
+                    ) / golfer_stats.num_par_3_holes
+                elif hole.par == 4:
+                    golfer_stats.num_par_4_holes += 1
+                    golfer_stats.avg_par_4_gross += (
+                        hole_result.gross_score - golfer_stats.avg_par_4_gross
+                    ) / golfer_stats.num_par_4_holes
+                    golfer_stats.avg_par_4_net += (
+                        hole_result.net_score - golfer_stats.avg_par_4_net
+                    ) / golfer_stats.num_par_4_holes
+                elif hole.par == 5:
+                    golfer_stats.num_par_5_holes += 1
+                    golfer_stats.avg_par_5_gross += (
+                        hole_result.gross_score - golfer_stats.avg_par_5_gross
+                    ) / golfer_stats.num_par_5_holes
+                    golfer_stats.avg_par_5_net += (
+                        hole_result.net_score - golfer_stats.avg_par_5_net
+                    ) / golfer_stats.num_par_5_holes
+
+            golfer_stats.avg_gross += (
+                gross_score - golfer_stats.avg_gross
+            ) / golfer_stats.num_rounds
+            golfer_stats.avg_gross_to_par += (
+                (gross_score - par) - golfer_stats.avg_gross_to_par
+            ) / golfer_stats.num_rounds
+
+            golfer_stats.avg_net += (
+                net_score - golfer_stats.avg_net
+            ) / golfer_stats.num_rounds
+            golfer_stats.avg_net_to_par += (
+                (net_score - par) - golfer_stats.avg_net_to_par
+            ) / golfer_stats.num_rounds
+
+    flight_stats = FlightStatistics(
+        flight_id=flight_id, golfers=list(flight_golfer_stats.values())
+    )
+    flight_stats.golfers.sort(key=lambda g: g.avg_gross)
+
+    return flight_stats

--- a/app/database/flights.py
+++ b/app/database/flights.py
@@ -260,7 +260,15 @@ def get_statistics(session: Session, flight_id: int) -> FlightStatistics:
             golfer_stats.num_matches += 1
             golfer_stats.num_rounds += 1  # TODO: track repeat rounds
 
-            # TODO: update total and average points won
+            points_won = 0
+            if golfer_stats.golfer_team_id == golfer_match.home_team_id:
+                points_won = golfer_match.home_score
+            elif golfer_stats.golfer_team_id == golfer_match.away_team_id:
+                points_won = golfer_match.away_score
+            golfer_stats.points_won += points_won
+            golfer_stats.avg_points_won += (
+                points_won - golfer_stats.avg_points_won
+            ) / golfer_stats.num_matches
 
             par = 0
             gross_score = 0

--- a/app/models/division.py
+++ b/app/models/division.py
@@ -60,3 +60,24 @@ class DivisionData(SQLModel):
     secondary_tee_name: str
     secondary_tee_rating: float
     secondary_tee_slope: int
+
+
+class FlightDivision(SQLModel):
+    id: int
+    flight_id: int
+    name: str
+    gender: str
+    primary_track_id: int
+    primary_track_name: str
+    primary_tee_id: int
+    primary_tee_name: str
+    primary_tee_par: int
+    primary_tee_rating: float
+    primary_tee_slope: int
+    secondary_track_id: int
+    secondary_track_name: str
+    secondary_tee_id: int
+    secondary_tee_par: int
+    secondary_tee_name: str
+    secondary_tee_rating: float
+    secondary_tee_slope: int

--- a/app/models/flight.py
+++ b/app/models/flight.py
@@ -105,29 +105,12 @@ class FlightStandings(BaseModel):
     teams: list[FlightStandingsTeam]
 
 
-class FlightStatisticsGolfer(BaseModel):
-    golfer_id: int
-    golfer_name: str
-    golfer_team_id: int
-    golfer_team_role: TeamRole
-    num_matches: int = 0
-    num_rounds: int = 0
-    points_won: float = 0
-    avg_points_won: float = 0
-    avg_gross: float = 0
-    avg_gross_to_par: float = 0
-    avg_net: float = 0
-    avg_net_to_par: float = 0
-    num_holes: int = 0
-    num_par_3_holes: int = 0
-    num_par_4_holes: int = 0
-    num_par_5_holes: int = 0
-    avg_par_3_gross: float = 0
-    avg_par_3_net: float = 0
-    avg_par_4_gross: float = 0
-    avg_par_4_net: float = 0
-    avg_par_5_gross: float = 0
-    avg_par_5_net: float = 0
+class GolferStatisticsScoring(BaseModel):
+    avg_score: float = 0
+    avg_score_to_par: float = 0
+    avg_par_3_score: float = 0
+    avg_par_4_score: float = 0
+    avg_par_5_score: float = 0
     num_aces: int = 0
     num_albatrosses: int = 0
     num_eagles: int = 0
@@ -138,6 +121,26 @@ class FlightStatisticsGolfer(BaseModel):
     num_others: int = 0
 
 
+class GolferStatistics(BaseModel):
+    golfer_id: int
+    golfer_name: str
+    golfer_team_id: int
+    golfer_team_role: TeamRole
+    num_rounds: int = 0
+    num_holes: int = 0
+    num_par_3_holes: int = 0
+    num_par_4_holes: int = 0
+    num_par_5_holes: int = 0
+    gross_scoring: GolferStatisticsScoring = GolferStatisticsScoring()
+    net_scoring: GolferStatisticsScoring = GolferStatisticsScoring()
+
+
+class FlightGolferStatistics(GolferStatistics):
+    num_matches: int = 0
+    points_won: float = 0
+    avg_points_won: float = 0
+
+
 class FlightStatistics(BaseModel):
     flight_id: int
-    golfers: list[FlightStatisticsGolfer] = Field(default_factory=list)
+    golfers: list[FlightGolferStatistics] = Field(default_factory=list)

--- a/app/models/flight.py
+++ b/app/models/flight.py
@@ -103,3 +103,41 @@ class FlightStandingsTeam(BaseModel):
 class FlightStandings(BaseModel):
     flight_id: int
     teams: list[FlightStandingsTeam]
+
+
+class FlightStatisticsGolfer(BaseModel):
+    golfer_id: int
+    golfer_name: str
+    golfer_team_id: int
+    golfer_team_role: TeamRole
+    num_matches: int = 0
+    num_rounds: int = 0
+    points_won: float = 0
+    avg_points_won: float = 0
+    avg_gross: float = 0
+    avg_gross_to_par: float = 0
+    avg_net: float = 0
+    avg_net_to_par: float = 0
+    num_holes: int = 0
+    num_par_3_holes: int = 0
+    num_par_4_holes: int = 0
+    num_par_5_holes: int = 0
+    avg_par_3_gross: float = 0
+    avg_par_3_net: float = 0
+    avg_par_4_gross: float = 0
+    avg_par_4_net: float = 0
+    avg_par_5_gross: float = 0
+    avg_par_5_net: float = 0
+    num_aces: int = 0
+    num_albatrosses: int = 0
+    num_eagles: int = 0
+    num_birdies: int = 0
+    num_pars: int = 0
+    num_bogeys: int = 0
+    num_double_bogeys: int = 0
+    num_others: int = 0
+
+
+class FlightStatistics(BaseModel):
+    flight_id: int
+    golfers: list[FlightStatisticsGolfer] = Field(default_factory=list)

--- a/app/routers/flights.py
+++ b/app/routers/flights.py
@@ -181,6 +181,15 @@ async def get_info(
     return db_flights.get_info(session=session, flight_id=flight_id)
 
 
+@router.get("/divisions/{flight_id}")
+async def get_divisions(
+    *,
+    session: Session = Depends(get_sql_db_session),
+    flight_id: int = Path(..., description="Flight identifier"),
+):
+    return db_flights.get_divisions(session=session, flight_id=flight_id)
+
+
 @router.get("/teams/{flight_id}")
 async def get_teams(
     *,

--- a/app/routers/flights.py
+++ b/app/routers/flights.py
@@ -215,3 +215,12 @@ async def get_standings(
     flight_id: int = Path(..., description="Flight identifier"),
 ):
     return db_flights.get_standings(session=session, flight_id=flight_id)
+
+
+@router.get("/statistics/{flight_id}")
+async def get_statistics(
+    *,
+    session: Session = Depends(get_sql_db_session),
+    flight_id: int = Path(..., description="Flight identifier"),
+):
+    return db_flights.get_statistics(session=session, flight_id=flight_id)


### PR DESCRIPTION
This PR adds database utilities to the `flights` module to fetch divisions and golfer statistics for a given flight. These are exposed in the flights router of the API.