### PR TITLE
Add validation to golfer registration

### DIFF
--- a/app/routers/golfers.py
+++ b/app/routers/golfers.py
@@ -77,6 +77,9 @@ async def create_golfer(
             detail=f"Invalid golfer registration, email is required",
         )
 
+    # Convert name to title case
+    golfer.name = golfer.name.title()
+
     # Add to database
     golfer_db = Golfer.model_validate(golfer)
     session.add(golfer_db)

--- a/app/routers/golfers.py
+++ b/app/routers/golfers.py
@@ -1,4 +1,6 @@
+import re
 from datetime import date, timedelta
+from http import HTTPStatus
 from typing import List
 
 from fastapi import APIRouter, Depends, Query
@@ -44,6 +46,38 @@ async def read_all_golfers(*, session: Session = Depends(get_sql_db_session)):
 async def create_golfer(
     *, session: Session = Depends(get_sql_db_session), golfer: GolferCreate
 ):
+    # Validate entries
+    if len(golfer.name) < 3:
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST,
+            detail=f"Invalid golfer name, too short (min: 3 characters)",
+        )
+
+    if len(golfer.name) > 25:
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST,
+            detail=f"Invalid golfer name, too long (max: 25 characters)",
+        )
+
+    if not bool(re.fullmatch(r"[a-zA-Z0-9\s\-\']+", golfer.name)):
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST,
+            detail=f"Invalid characters in golfer name",
+        )
+
+    if golfer.affiliation is None:
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST,
+            detail=f"Invalid golfer registration, affiliation is required",
+        )
+
+    if golfer.email is None:
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST,
+            detail=f"Invalid golfer registration, email is required",
+        )
+
+    # Add to database
     golfer_db = Golfer.model_validate(golfer)
     session.add(golfer_db)
     session.commit()

--- a/app/routers/teams.py
+++ b/app/routers/teams.py
@@ -273,10 +273,10 @@ def validate_team_signup_data(
             detail=f"Invalid team name, too short (min: 3 characters)",
         )
 
-    if len(team_data.name) > 20:
+    if len(team_data.name) > 25:
         raise HTTPException(
             status_code=HTTPStatus.BAD_REQUEST,
-            detail=f"Invalid team name, too long (max: 20 characters)",
+            detail=f"Invalid team name, too long (max: 25 characters)",
         )
 
     if not bool(re.fullmatch(r"[a-zA-Z0-9\s\-\']+", team_data.name)):

--- a/tests/routers/test_router_golfers.py
+++ b/tests/routers/test_router_golfers.py
@@ -7,22 +7,57 @@ from app.models.golfer import Golfer, GolferAffiliation
 
 
 @pytest.mark.parametrize(
-    "name, affiliation",
+    "name, affiliation, email, phone",
     [
-        ("Test Golfer", GolferAffiliation.APL_EMPLOYEE),
-        ("Test Golfer", None),
+        ("Test Golfer", GolferAffiliation.APL_EMPLOYEE, "test@email.com", None),
+        (
+            "Test Golfer",
+            GolferAffiliation.APL_EMPLOYEE,
+            "test@email.com",
+            "123-456-7890",
+        ),
     ],
 )
-def test_create_golfer(client_unauthorized: TestClient, name: str, affiliation: str):
+def test_create_golfer(
+    client_unauthorized: TestClient, name: str, affiliation: str, email: str, phone: str
+):
     response = client_unauthorized.post(
-        "/golfers/", json={"name": name, "affiliation": affiliation}
+        "/golfers/",
+        json={"name": name, "affiliation": affiliation, "email": email, "phone": phone},
     )
     assert response.status_code == status.HTTP_200_OK
 
     data = response.json()
     assert data["name"] == name
     assert data["affiliation"] == affiliation
+    assert data["email"] == email
+    assert data["phone"] == phone
     assert data["id"] is not None
+
+
+@pytest.mark.parametrize(
+    "name, affiliation, email, phone",
+    [
+        (
+            "Test Golfer With Name Much Too Long",
+            GolferAffiliation.APL_EMPLOYEE,
+            "test@email.com",
+            None,
+        ),
+        ("A", GolferAffiliation.APL_EMPLOYEE, "test@email.com", None),
+        ("!nvalid CH@RS!", GolferAffiliation.APL_EMPLOYEE, "test@email.com", None),
+        ("Missing Affiliation", None, "test@email.com", None),
+        ("Missing Email", GolferAffiliation.APL_EMPLOYEE, None, None),
+    ],
+)
+def test_create_golfer_invalid(
+    client_unauthorized: TestClient, name: str, affiliation: str, email: str, phone: str
+):
+    response = client_unauthorized.post(
+        "/golfers/",
+        json={"name": name, "affiliation": affiliation, "email": email, "phone": phone},
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
 def test_create_golfer_incomplete(client_unauthorized: TestClient):


### PR DESCRIPTION
This PR adds server-side validation to golfer registrations, in addition to the front-end validations. This includes name length and character restrictions and title case, plus required email and affiliation.