### PR TITLE
Explicitly link matches and rounds to teams

### DIFF
--- a/app/models/match_round_link.py
+++ b/app/models/match_round_link.py
@@ -2,5 +2,6 @@ from sqlmodel import Field, SQLModel
 
 
 class MatchRoundLink(SQLModel, table=True):
-    match_id: int = Field(default=None, foreign_key="match.id", primary_key=True)
-    round_id: int = Field(default=None, foreign_key="round.id", primary_key=True)
+    match_id: int = Field(..., foreign_key="match.id", primary_key=True)
+    round_id: int = Field(..., foreign_key="round.id", primary_key=True)
+    team_id: int = Field(..., foreign_key="team.id")

--- a/app/models/query_helpers.py
+++ b/app/models/query_helpers.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from typing import List, Optional
 
 from sqlalchemy.orm import aliased
-from sqlmodel import Session, SQLModel, and_, desc, or_, select
+from sqlmodel import Session, SQLModel, desc, or_, select
 
 from app.models.course import Course
 from app.models.division import Division, DivisionData
@@ -914,20 +914,7 @@ def get_flight_rounds(session: Session, round_ids: List[int]) -> List[RoundResul
         .join(Track)
         .join(Course)
         .join(Golfer, onclause=Golfer.id == RoundGolferLink.golfer_id)
-        .join(Match, onclause=Match.id == MatchRoundLink.match_id)
-        .join(
-            TeamGolferLink,
-            onclause=(
-                and_(
-                    TeamGolferLink.golfer_id == Golfer.id,
-                    or_(
-                        TeamGolferLink.team_id == Match.home_team_id,
-                        TeamGolferLink.team_id == Match.away_team_id,
-                    ),
-                )
-            ),
-        )
-        .join(Team, onclause=Team.id == TeamGolferLink.team_id)
+        .join(Team, onclause=Team.id == MatchRoundLink.team_id)
         .where(Round.id.in_(round_ids))
     )
     round_data = [


### PR DESCRIPTION
This PR adds a new required field to the MatchRoundLink model for the team id. This used to be inferred from golfers and team golfer links, but that's unnecessarily complicated and doesn't work well with the new substitutes construct.