### PR TITLE
Fix 18 week 7 team schedule

### DIFF
--- a/app/tasks/matches.py
+++ b/app/tasks/matches.py
@@ -97,7 +97,7 @@ def initialize_matches_for_flight(
             [5, 6, 7, 5, 1, 2, 3],  # week 8 (extra: 5 vs 4)
             [4, 3, 2, 1, 7, 1, 5],  # week 9 (extra: 1 vs 6)
             [7, 4, 6, 2, None, 3, 1],  # week 10
-            [None, 7, 4, 3, 1, 5, 2],  # week 11
+            [None, 7, 4, 3, 6, 5, 2],  # week 11
             [2, 1, None, 6, 7, 4, 5],  # week 12
             [7, None, 6, 5, 4, 3, 1],  # week 13
             [None, 6, 5, 7, 3, 2, 4],  # week 14

--- a/app/tasks/matches.py
+++ b/app/tasks/matches.py
@@ -94,10 +94,10 @@ def initialize_matches_for_flight(
             [2, 1, None, 6, 7, 4, 5],  # week 5
             [7, None, 6, 5, 4, 3, 1],  # week 6
             [None, 6, 5, 7, 3, 2, 4],  # week 7
-            [6, 5, 4, 3, 2, 1, 5],  # week 8
-            [5, 4, 7, 2, 1, 4, 3],  # week 9
-            [4, 3, 2, 1, 7, 7, 6],  # week 10
-            [3, 7, 1, 6, 6, 5, 2],  # week 11
+            [5, 6, 7, 5, 1, 2, 3],  # week 8 (extra: 5 vs 4)
+            [4, 3, 2, 1, 7, 1, 5],  # week 9 (extra: 1 vs 6)
+            [7, 4, 6, 2, None, 3, 1],  # week 10
+            [None, 7, 4, 3, 1, 5, 2],  # week 11
             [2, 1, None, 6, 7, 4, 5],  # week 12
             [7, None, 6, 5, 4, 3, 1],  # week 13
             [None, 6, 5, 7, 3, 2, 4],  # week 14


### PR DESCRIPTION
This PR fixes the match setup task to correct additional extra matches that were added into the middle weeks. Thanks for John D. for the resource from League Lobster to generate a schedule and debug the differences!