### PR TITLE
Add force flag to schedule init

### DIFF
--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -14,7 +14,14 @@ from app.utilities.notifications import EmailSchema, send_email
 app = Rocketry(execution="async")
 
 
-@app.task(parameters={"flight_id": -1, "bye_weeks_by_team": None, "dry_run": False})
+@app.task(
+    parameters={
+        "flight_id": -1,
+        "bye_weeks_by_team": None,
+        "dry_run": False,
+        "force": False,
+    }
+)
 async def initialize_flight_schedule(
     flight_id: int, bye_weeks_by_team: str | None, dry_run: bool, force: bool
 ):

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -16,7 +16,7 @@ app = Rocketry(execution="async")
 
 @app.task(parameters={"flight_id": -1, "bye_weeks_by_team": None, "dry_run": False})
 async def initialize_flight_schedule(
-    flight_id: int, bye_weeks_by_team: str | None, dry_run: bool
+    flight_id: int, bye_weeks_by_team: str | None, dry_run: bool, force: bool
 ):
     if bye_weeks_by_team is None:
         bye_week_requests = None
@@ -31,6 +31,7 @@ async def initialize_flight_schedule(
             flight_id=flight_id,
             bye_weeks_by_team=bye_week_requests,
             dry_run=dry_run,
+            force=force,
         )
 
 

--- a/app/tasks/matches.py
+++ b/app/tasks/matches.py
@@ -11,6 +11,7 @@ def initialize_matches_for_flight(
     flight_id: int,
     bye_weeks_by_team: dict[int, int] | None = None,
     dry_run: bool = False,
+    force: bool = False,
 ):
     flight_db = session.get(Flight, flight_id)
     if flight_db is None:
@@ -37,7 +38,7 @@ def initialize_matches_for_flight(
     existing_matches = session.exec(
         select(Match).where(Match.flight_id == flight_id)
     ).all()
-    if len(existing_matches) > 0:
+    if not force and len(existing_matches) > 0:
         raise ValueError(
             f"Matches already exist for flight: '{flight_db.name} ({flight_db.year})' (id={flight_id})"
         )


### PR DESCRIPTION
This PR adds an optional flag to the flight schedule initialization task which forces it to run even if matches already exist for this flight in the database. Existing matches will be skipped later in the task anyway, so duplicates should still not happen.