### PR TITLE
Add shamble mode

### DIFF
--- a/app/database/tournaments.py
+++ b/app/database/tournaments.py
@@ -70,6 +70,7 @@ def get_info(session: Session, tournament_id: int) -> TournamentInfo:
         strokeplay=tournament.strokeplay,
         bestball=tournament.bestball,
         scramble=tournament.scramble,
+        shamble=tournament.shamble,
         ryder_cup=tournament.ryder_cup,
         individual=tournament.individual,
         chachacha=tournament.chachacha,

--- a/app/models/query_helpers.py
+++ b/app/models/query_helpers.py
@@ -139,6 +139,7 @@ class TournamentData(SQLModel):
     strokeplay: bool = False
     bestball: int = 0
     scramble: bool = False
+    shamble: bool = False
     ryder_cup: bool = False
     individual: bool = False
     chachacha: bool = False
@@ -277,6 +278,7 @@ def get_tournaments(
             strokeplay=tournament.strokeplay,
             bestball=tournament.bestball,
             scramble=tournament.scramble,
+            shamble=tournament.shamble,
             ryder_cup=tournament.ryder_cup,
             individual=tournament.individual,
             chachacha=tournament.chachacha,

--- a/app/models/tournament.py
+++ b/app/models/tournament.py
@@ -29,6 +29,7 @@ class TournamentBase(SQLModel):
     strokeplay: bool | None = False
     bestball: int | None = 0
     scramble: bool | None = False
+    shamble: bool | None = False
     ryder_cup: bool | None = False
     individual: bool | None = False
     chachacha: bool | None = False
@@ -64,6 +65,7 @@ class TournamentUpdate(SQLModel):
     strokeplay: bool | None = None
     bestball: int | None = None
     scramble: bool | None = None
+    shamble: bool | None = None
     ryder_cup: bool | None = None
     individual: bool | None = None
     chachacha: bool | None = None
@@ -94,6 +96,7 @@ class TournamentInfo(SQLModel):
     strokeplay: bool = False
     bestball: int = 0
     scramble: bool = False
+    shamble: bool = False
     ryder_cup: bool = False
     individual: bool = False
     chachacha: bool = False

--- a/app/tasks/compute_tournament_handicaps.py
+++ b/app/tasks/compute_tournament_handicaps.py
@@ -97,6 +97,11 @@ if __name__ == "__main__":
             select(Course).where(Course.id == tournament_db.course_id)
         ).one()
 
+        # Get handicap allowance
+        handicap_allowance = ahs.get_handicap_allowance(
+            is_shamble=(not (tournament_db.shamble is None) and tournament_db.shamble)
+        )
+
         # Get divisions and associated tees for this tournament
         divisions_list = session.exec(
             select(Division)
@@ -178,7 +183,10 @@ if __name__ == "__main__":
                     handicap_index=golfer_db.handicap_index,
                 )
 
-            course_handicap = round(course_handicap_primary + course_handicap_secondary)
+            course_handicap = round(
+                handicap_allowance
+                * (course_handicap_primary + course_handicap_secondary)
+            )
 
             GOLFER_DATA.append(
                 [

--- a/app/utilities/apl_handicap_system.py
+++ b/app/utilities/apl_handicap_system.py
@@ -50,3 +50,17 @@ class APLHandicapSystem(APLLegacyHandicapSystem):
 
         """
         return 2 * par + handicap_strokes
+
+    def get_handicap_allowance(self, is_shamble: bool = False) -> float:
+        """
+        Determines the handicap allowance for a round given the type of event being played.
+
+        Returns
+        -------
+        allowance : float
+            scaling factor for handicaps in this scoring mode, in range [0, 1]
+
+        """
+        if is_shamble:
+            return 0.7
+        return 1.0


### PR DESCRIPTION
This PR adds a new scoring mode `shamble` for tournaments. These tournaments reduce handicap allowances to 70% of normal for individuals. Note that incoming rounds when posted should be counted as GROUP rounds (to avoid handicapping impacts).