### PR TITLE
Add golfer name uniqueness check

### DIFF
--- a/app/database/golfers.py
+++ b/app/database/golfers.py
@@ -1,3 +1,7 @@
+import re
+from dataclasses import dataclass
+
+from rapidfuzz import fuzz
 from sqlmodel import Session, select
 
 from app.models.golfer import Golfer, GolferStatistics
@@ -5,6 +9,104 @@ from app.models.hole import Hole
 from app.models.hole_result import HoleResult
 from app.models.round import Round, ScoringType
 from app.models.round_golfer_link import RoundGolferLink
+
+
+@dataclass
+class NameMatch:
+    id: int
+    name: str
+    score: float
+
+
+@dataclass
+class NameCheckResult:
+    is_unique: bool
+    exact_matches: list[NameMatch]
+    possible_matches: list[NameMatch]
+
+
+def normalize_name(name: str) -> str:
+    """Trim, collapse whitespace, lowercase."""
+    return re.sub(r"\s+", " ", name.strip()).lower()
+
+
+def find_exact_matches(session: Session, normalized_name: str) -> list[Golfer]:
+    """
+    Finds exact matches using Python-side normalization for consistency.
+    For large datasets, this could be pushed into SQL instead.
+    """
+    golfers = session.exec(select(Golfer)).all()
+
+    return [g for g in golfers if normalize_name(g.name) == normalized_name]
+
+
+def score_name(a: str, b: str) -> float:
+    """
+    Returns similarity score in [0, 1].
+    token_sort_ratio handles word order differences well.
+    """
+    return fuzz.token_sort_ratio(a, b) / 100.0
+
+
+def find_fuzzy_matches(
+    input_name: str, candidates: list[Golfer], threshold: float = 0.7, limit: int = 5
+) -> list[NameMatch]:
+    norm_input = normalize_name(input_name)
+
+    results: list[NameMatch] = []
+
+    for g in candidates:
+        norm_candidate = normalize_name(g.name)
+        score = score_name(norm_input, norm_candidate)
+
+        if score >= threshold:
+            results.append(NameMatch(id=g.id, name=g.name, score=score))
+
+    return sorted(results, key=lambda x: x.score, reverse=True)[:limit]
+
+
+def check_golfer_name_uniqueness(
+    session: Session,
+    name: str,
+    fuzzy_threshold: float = 0.7,
+    hard_block_threshold: float = 0.85,
+) -> NameCheckResult:
+    """
+    Checks whether a golfer name is unique.
+
+    Behavior:
+    - Exact normalized match → NOT unique (hard fail)
+    - High fuzzy match (>= hard_block_threshold) → NOT unique
+    - Medium fuzzy match → allowed but flagged
+    """
+
+    normalized = normalize_name(name)
+
+    # 1. Exact match check
+    exact = find_exact_matches(session, normalized)
+    exact_matches = [NameMatch(id=g.id, name=g.name, score=1.0) for g in exact]
+
+    if exact_matches:
+        return NameCheckResult(
+            is_unique=False, exact_matches=exact_matches, possible_matches=[]
+        )
+
+    # 2. Fuzzy match check
+    candidates = list(session.exec(select(Golfer)).all())
+
+    fuzzy_matches = find_fuzzy_matches(name, candidates, threshold=fuzzy_threshold)
+
+    # 3. Decision logic
+    is_unique = True
+
+    if fuzzy_matches:
+        top_score = fuzzy_matches[0].score
+        if top_score >= hard_block_threshold:
+            is_unique = False
+
+    return NameCheckResult(
+        is_unique=is_unique, exact_matches=[], possible_matches=fuzzy_matches
+    )
 
 
 def get_statistics(

--- a/app/routers/golfers.py
+++ b/app/routers/golfers.py
@@ -84,8 +84,15 @@ async def create_golfer(
             detail=f"Invalid golfer registration, email is required",
         )
 
-    # Convert name to title case
     golfer.name = golfer.name.title()
+    name_check = db_golfers.check_golfer_name_uniqueness(
+        session=session, name=golfer.name, hard_block_threshold=0.9
+    )
+    if not name_check.is_unique:
+        raise HTTPException(
+            status_code=HTTPStatus.CONFLICT,
+            detail=f"Invalid golfer registration, golfer with name '{golfer.name}' already exists",
+        )
 
     # Add to database
     golfer_db = Golfer.model_validate(golfer)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "pymongo>=4.3.3,<5.0.0",
     "python-jose[cryptography]>=3.3.0,<4.0.0",
     "python-multipart>=0.0.7,<1.0.0",
+    "rapidfuzz>=3.14.3",
     "rocketry>=2.5.1,<3.0.0",
     "sqlmodel>=0.0.4,<1.0.0",
     "uvicorn>=0.15.0,<1.0.0",

--- a/tests/database/test_database_golfers.py
+++ b/tests/database/test_database_golfers.py
@@ -1,0 +1,104 @@
+import pytest
+from sqlmodel import Session
+
+from app.database import golfers as db_golfers
+from app.models.golfer import Golfer, GolferAffiliation
+
+
+@pytest.mark.parametrize(
+    "input_name, expected",
+    [
+        ("  John  Doe  ", "john doe"),
+        ("Jane Smith", "jane smith"),
+        ("BOB", "bob"),
+        ("  Multiple   Spaces  ", "multiple spaces"),
+    ],
+)
+def test_normalize_name(input_name: str, expected: str):
+    assert db_golfers.normalize_name(input_name) == expected
+
+
+@pytest.mark.parametrize(
+    "search_name, expected_count",
+    [
+        ("john doe", 1),
+        ("  JOHN  DOE  ", 1),
+        ("nonexistent", 0),
+        ("jane smith", 1),
+    ],
+)
+def test_find_exact_matches(session: Session, search_name: str, expected_count: int):
+    golfer1 = Golfer(name="John Doe", affiliation=GolferAffiliation.APL_EMPLOYEE)
+    golfer2 = Golfer(name="Jane Smith", affiliation=GolferAffiliation.APL_EMPLOYEE)
+    session.add(golfer1)
+    session.add(golfer2)
+    session.commit()
+
+    # Normalize search_name because find_exact_matches expects normalized input
+    normalized_search = db_golfers.normalize_name(search_name)
+    matches = db_golfers.find_exact_matches(session, normalized_search)
+    assert len(matches) == expected_count
+    if expected_count > 0:
+        assert db_golfers.normalize_name(matches[0].name) == normalized_search
+
+
+@pytest.mark.parametrize(
+    "name_a, name_b, expected_score",
+    [
+        ("john doe", "doe john", 1.0),
+        ("john doe", "john doe", 1.0),
+        ("john doe", "jane doe", 0.75),  # RapidFuzz score for this pair
+    ],
+)
+def test_score_name(name_a: str, name_b: str, expected_score: float):
+    # We use >= or close comparison if needed, but for these exact ones:
+    assert db_golfers.score_name(name_a, name_b) == pytest.approx(
+        expected_score, abs=0.01
+    )
+
+
+@pytest.mark.parametrize(
+    "query_name, threshold, expected_matches_count",
+    [
+        ("Jon Doe", 0.8, 1),
+        ("Jane Smith", 0.8, 0),
+    ],
+)
+def test_find_fuzzy_matches(
+    session: Session, query_name: str, threshold: float, expected_matches_count: int
+):
+    golfer1 = Golfer(name="John Doe", affiliation=GolferAffiliation.APL_EMPLOYEE)
+    session.add(golfer1)
+    session.commit()
+
+    candidates = [golfer1]
+    matches = db_golfers.find_fuzzy_matches(query_name, candidates, threshold=threshold)
+    assert len(matches) == expected_matches_count
+    if expected_matches_count > 0:
+        assert matches[0].name == "John Doe"
+
+
+@pytest.mark.parametrize(
+    "name_to_check, expected_unique, expected_exact_count, expected_fuzzy_count",
+    [
+        ("John Doe", False, 1, 0),  # Exact match
+        ("Jon Doe", False, 0, 1),  # Fuzzy match (high score > 0.85)
+        ("Jane Doe", True, 0, 1),  # Fuzzy match (low score < 0.85)
+        ("Jane Smith", True, 0, 0),  # Unique
+    ],
+)
+def test_check_golfer_name_uniqueness(
+    session: Session,
+    name_to_check: str,
+    expected_unique: bool,
+    expected_exact_count: int,
+    expected_fuzzy_count: int,
+):
+    golfer1 = Golfer(name="John Doe", affiliation=GolferAffiliation.APL_EMPLOYEE)
+    session.add(golfer1)
+    session.commit()
+
+    result = db_golfers.check_golfer_name_uniqueness(session, name_to_check)
+    assert result.is_unique == expected_unique
+    assert len(result.exact_matches) == expected_exact_count
+    assert len(result.possible_matches) == expected_fuzzy_count

--- a/tests/routers/test_router_golfers.py
+++ b/tests/routers/test_router_golfers.py
@@ -92,6 +92,40 @@ def test_create_golfer_invalid(
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
 
+@pytest.mark.parametrize(
+    "first_name, second_name",
+    [
+        ("Duplicate Golfer", "Duplicate Golfer"),
+        ("Duplicate Golfer", "duplicate golfer"),
+        ("Duplicate Golfer", "  DUPLICATE   GOLFER  "),
+    ],
+)
+def test_create_golfer_duplicate_name(
+    session: Session, client_unauthorized: TestClient, first_name: str, second_name: str
+):
+    # First golfer
+    email1 = "first@example.com"
+    affiliation = GolferAffiliation.APL_EMPLOYEE
+
+    response = client_unauthorized.post(
+        "/golfers/",
+        json={"name": first_name, "affiliation": affiliation, "email": email1},
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    # Attempt to create another with same (or similar normalized) name
+    response = client_unauthorized.post(
+        "/golfers/",
+        json={
+            "name": second_name,
+            "affiliation": affiliation,
+            "email": "second@example.com",
+        },
+    )
+    assert response.status_code == status.HTTP_409_CONFLICT
+    assert "already exists" in response.json()["detail"]
+
+
 def test_read_golfers(session: Session, client_unauthorized: TestClient):
     golfers = [
         Golfer(name="Test Golfer A", affiliation=GolferAffiliation.NON_APL_EMPLOYEE),

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = "==3.12.*"
 resolution-markers = [
     "sys_platform == 'win32'",
@@ -72,6 +72,7 @@ dependencies = [
     { name = "pymongo" },
     { name = "python-jose", extra = ["cryptography"] },
     { name = "python-multipart" },
+    { name = "rapidfuzz" },
     { name = "rocketry" },
     { name = "sqlmodel" },
     { name = "uvicorn" },
@@ -107,6 +108,7 @@ requires-dist = [
     { name = "pymongo", specifier = ">=4.3.3,<5.0.0" },
     { name = "python-jose", extras = ["cryptography"], specifier = ">=3.3.0,<4.0.0" },
     { name = "python-multipart", specifier = ">=0.0.7,<1.0.0" },
+    { name = "rapidfuzz", specifier = ">=3.14.3" },
     { name = "rocketry", specifier = ">=2.5.1,<3.0.0" },
     { name = "sqlmodel", specifier = ">=0.0.4,<1.0.0" },
     { name = "uvicorn", specifier = ">=0.15.0,<1.0.0" },
@@ -494,6 +496,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/ab/1608e5a7578e62113506740b88066bf09888322a311cff602105e619bd87/greenlet-3.3.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:ac8d61d4343b799d1e526db579833d72f23759c71e07181c2d2944e429eb09cd", size = 280358, upload-time = "2026-02-20T20:17:43.971Z" },
     { url = "https://files.pythonhosted.org/packages/a5/23/0eae412a4ade4e6623ff7626e38998cb9b11e9ff1ebacaa021e4e108ec15/greenlet-3.3.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ceec72030dae6ac0c8ed7591b96b70410a8be370b6a477b1dbc072856ad02bd", size = 601217, upload-time = "2026-02-20T20:47:31.462Z" },
     { url = "https://files.pythonhosted.org/packages/f8/16/5b1678a9c07098ecb9ab2dd159fafaf12e963293e61ee8d10ecb55273e5e/greenlet-3.3.2-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a2a5be83a45ce6188c045bcc44b0ee037d6a518978de9a5d97438548b953a1ac", size = 611792, upload-time = "2026-02-20T20:55:58.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/c5/cc09412a29e43406eba18d61c70baa936e299bc27e074e2be3806ed29098/greenlet-3.3.2-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae9e21c84035c490506c17002f5c8ab25f980205c3e61ddb3a2a2a2e6c411fcb", size = 626250, upload-time = "2026-02-20T21:02:46.596Z" },
     { url = "https://files.pythonhosted.org/packages/50/1f/5155f55bd71cabd03765a4aac9ac446be129895271f73872c36ebd4b04b6/greenlet-3.3.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43e99d1749147ac21dde49b99c9abffcbc1e2d55c67501465ef0930d6e78e070", size = 613875, upload-time = "2026-02-20T20:21:01.102Z" },
     { url = "https://files.pythonhosted.org/packages/fc/dd/845f249c3fcd69e32df80cdab059b4be8b766ef5830a3d0aa9d6cad55beb/greenlet-3.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4c956a19350e2c37f2c48b336a3afb4bff120b36076d9d7fb68cb44e05d95b79", size = 1571467, upload-time = "2026-02-20T20:49:33.495Z" },
     { url = "https://files.pythonhosted.org/packages/2a/50/2649fe21fcc2b56659a452868e695634722a6655ba245d9f77f5656010bf/greenlet-3.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c6f8ba97d17a1e7d664151284cb3315fc5f8353e75221ed4324f84eb162b395", size = 1640001, upload-time = "2026-02-20T20:21:09.154Z" },
@@ -1229,6 +1232,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/2f/104c0a3c778d7c2ab8190e9db4f62f0b6957b53c9d87db77c284b69f33ea/pyzmq-27.1.0-cp312-abi3-win32.whl", hash = "sha256:250e5436a4ba13885494412b3da5d518cd0d3a278a1ae640e113c073a5f88edd", size = 559184, upload-time = "2025-09-08T23:08:15.163Z" },
     { url = "https://files.pythonhosted.org/packages/fc/7f/a21b20d577e4100c6a41795842028235998a643b1ad406a6d4163ea8f53e/pyzmq-27.1.0-cp312-abi3-win_amd64.whl", hash = "sha256:9ce490cf1d2ca2ad84733aa1d69ce6855372cb5ce9223802450c9b2a7cba0ccf", size = 619480, upload-time = "2025-09-08T23:08:17.192Z" },
     { url = "https://files.pythonhosted.org/packages/78/c2/c012beae5f76b72f007a9e91ee9401cb88c51d0f83c6257a03e785c81cc2/pyzmq-27.1.0-cp312-abi3-win_arm64.whl", hash = "sha256:75a2f36223f0d535a0c919e23615fc85a1e23b71f40c7eb43d7b1dedb4d8f15f", size = 552993, upload-time = "2025-09-08T23:08:18.926Z" },
+]
+
+[[package]]
+name = "rapidfuzz"
+version = "3.14.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/28/9d808fe62375b9aab5ba92fa9b29371297b067c2790b2d7cda648b1e2f8d/rapidfuzz-3.14.3.tar.gz", hash = "sha256:2491937177868bc4b1e469087601d53f925e8d270ccc21e07404b4b5814b7b5f", size = 57863900, upload-time = "2025-11-01T11:54:52.321Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/8e/3c215e860b458cfbedb3ed73bc72e98eb7e0ed72f6b48099604a7a3260c2/rapidfuzz-3.14.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:685c93ea961d135893b5984a5a9851637d23767feabe414ec974f43babbd8226", size = 1945306, upload-time = "2025-11-01T11:53:06.452Z" },
+    { url = "https://files.pythonhosted.org/packages/36/d9/31b33512015c899f4a6e6af64df8dfe8acddf4c8b40a4b3e0e6e1bcd00e5/rapidfuzz-3.14.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fa7c8f26f009f8c673fbfb443792f0cf8cf50c4e18121ff1e285b5e08a94fbdb", size = 1390788, upload-time = "2025-11-01T11:53:08.721Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/67/2ee6f8de6e2081ccd560a571d9c9063184fe467f484a17fa90311a7f4a2e/rapidfuzz-3.14.3-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:57f878330c8d361b2ce76cebb8e3e1dc827293b6abf404e67d53260d27b5d941", size = 1374580, upload-time = "2025-11-01T11:53:10.164Z" },
+    { url = "https://files.pythonhosted.org/packages/30/83/80d22997acd928eda7deadc19ccd15883904622396d6571e935993e0453a/rapidfuzz-3.14.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c5f545f454871e6af05753a0172849c82feaf0f521c5ca62ba09e1b382d6382", size = 3154947, upload-time = "2025-11-01T11:53:12.093Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/cf/9f49831085a16384695f9fb096b99662f589e30b89b4a589a1ebc1a19d34/rapidfuzz-3.14.3-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:07aa0b5d8863e3151e05026a28e0d924accf0a7a3b605da978f0359bb804df43", size = 1223872, upload-time = "2025-11-01T11:53:13.664Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/0f/41ee8034e744b871c2e071ef0d360686f5ccfe5659f4fd96c3ec406b3c8b/rapidfuzz-3.14.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73b07566bc7e010e7b5bd490fb04bb312e820970180df6b5655e9e6224c137db", size = 2392512, upload-time = "2025-11-01T11:53:15.109Z" },
+    { url = "https://files.pythonhosted.org/packages/da/86/280038b6b0c2ccec54fb957c732ad6b41cc1fd03b288d76545b9cf98343f/rapidfuzz-3.14.3-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:6de00eb84c71476af7d3110cf25d8fe7c792d7f5fa86764ef0b4ca97e78ca3ed", size = 2521398, upload-time = "2025-11-01T11:53:17.146Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/7b/05c26f939607dca0006505e3216248ae2de631e39ef94dd63dbbf0860021/rapidfuzz-3.14.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d7843a1abf0091773a530636fdd2a49a41bcae22f9910b86b4f903e76ddc82dc", size = 4259416, upload-time = "2025-11-01T11:53:19.34Z" },
+    { url = "https://files.pythonhosted.org/packages/40/eb/9e3af4103d91788f81111af1b54a28de347cdbed8eaa6c91d5e98a889aab/rapidfuzz-3.14.3-cp312-cp312-win32.whl", hash = "sha256:dea97ac3ca18cd3ba8f3d04b5c1fe4aa60e58e8d9b7793d3bd595fdb04128d7a", size = 1709527, upload-time = "2025-11-01T11:53:20.949Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/63/d06ecce90e2cf1747e29aeab9f823d21e5877a4c51b79720b2d3be7848f8/rapidfuzz-3.14.3-cp312-cp312-win_amd64.whl", hash = "sha256:b5100fd6bcee4d27f28f4e0a1c6b5127bc8ba7c2a9959cad9eab0bf4a7ab3329", size = 1538989, upload-time = "2025-11-01T11:53:22.428Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/6d/beee32dcda64af8128aab3ace2ccb33d797ed58c434c6419eea015fec779/rapidfuzz-3.14.3-cp312-cp312-win_arm64.whl", hash = "sha256:4e49c9e992bc5fc873bd0fff7ef16a4405130ec42f2ce3d2b735ba5d3d4eb70f", size = 811161, upload-time = "2025-11-01T11:53:23.811Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR adds uniqueness checks to golfer names in registration. If the name is exact or a very high confidence fuzzy match, the router will reject the new golfer registration as a conflict.