### PR TITLE
Change team name limit max to 32 characters

### DIFF
--- a/app/routers/teams.py
+++ b/app/routers/teams.py
@@ -287,10 +287,10 @@ def validate_team_signup_data(
             detail=f"Invalid team name, too short (min: 3 characters)",
         )
 
-    if len(team_data.name) > 25:
+    if len(team_data.name) > 32:
         raise HTTPException(
             status_code=HTTPStatus.BAD_REQUEST,
-            detail=f"Invalid team name, too long (max: 25 characters)",
+            detail=f"Invalid team name, too long (max: 32 characters)",
         )
 
     if not bool(re.fullmatch(r"[a-zA-Z0-9\s\-\']+", team_data.name)):


### PR DESCRIPTION
This PR increases the team name validation to 32 characters maximum.